### PR TITLE
Add comparison operator to variables. WIP.

### DIFF
--- a/graph/bolt/quadstore.go
+++ b/graph/bolt/quadstore.go
@@ -33,10 +33,10 @@ import (
 
 func init() {
 	graph.RegisterQuadStore(QuadStoreType, graph.QuadStoreRegistration{
-		NewFunc:           newQuadStore,
-		UpgradeFunc:       upgradeBolt,
-		InitFunc:          createNewBolt,
-		IsPersistent:      true,
+		NewFunc:      newQuadStore,
+		UpgradeFunc:  upgradeBolt,
+		InitFunc:     createNewBolt,
+		IsPersistent: true,
 	})
 }
 
@@ -305,6 +305,10 @@ func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreOpts graph.IgnoreOp
 		qs.size = oldSize
 	}
 	return err
+}
+
+func (qs *QuadStore) ApplyDeltaStream(in <-chan graph.Delta, opts graph.IgnoreOpts) error {
+	return nil
 }
 
 func (qs *QuadStore) buildQuadWrite(tx *bolt.Tx, q quad.Quad, id int64, isAdd bool) error {

--- a/graph/iterator/recursive.go
+++ b/graph/iterator/recursive.go
@@ -2,7 +2,6 @@ package iterator
 
 import (
 	"math"
-	"reflect"
 
 	"github.com/codelingo/cayley/graph"
 	"github.com/codelingo/cayley/quad"
@@ -103,7 +102,6 @@ func (it *Recursive) TagResults(dst map[string]graph.Value) {
 			dst[k] = v
 		}
 	}
-
 }
 
 func (it *Recursive) Clone() graph.Iterator {
@@ -196,12 +194,14 @@ func (it *Recursive) getBaseValue(val graph.Value) graph.Value {
 func (it *Recursive) ResetIfVarsUpdated(ctx *graph.IterationContext) {
 	if ctx != nil {
 		newVars := ctx.Values()
-		// Using reflect is not ideal, and we should also not be throwing all this
-		// information away, it could be useful if we have the same var value at a
-		// later point.
-		if !reflect.DeepEqual(newVars, it.vars) {
-			it.Reset()
-			it.vars = newVars
+		// We should not be throwing all this information away, it could be
+		// useful if we have the same var value at a later point.
+		for name, _ := range newVars {
+			if newVars[name] != it.vars[name] {
+				it.Reset()
+				it.vars = newVars
+				return
+			}
 		}
 	}
 }

--- a/graph/iterator/value_comparison.go
+++ b/graph/iterator/value_comparison.go
@@ -40,6 +40,7 @@ const (
 	CompareLTE
 	CompareGT
 	CompareGTE
+	CompareNoOp
 	// Why no Equals? Because that's usually an AndIterator.
 )
 
@@ -127,6 +128,8 @@ func RunIntOp(a quad.Int, op Operator, b quad.Int) bool {
 		return a > b
 	case CompareGTE:
 		return a >= b
+	case CompareNoOp:
+		return true
 	default:
 		panic("Unknown operator type")
 	}
@@ -142,6 +145,8 @@ func RunFloatOp(a quad.Float, op Operator, b quad.Float) bool {
 		return a > b
 	case CompareGTE:
 		return a >= b
+	case CompareNoOp:
+		return true
 	default:
 		panic("Unknown operator type")
 	}
@@ -157,6 +162,8 @@ func RunStrOp(a string, op Operator, b string) bool {
 		return a > b
 	case CompareGTE:
 		return a >= b
+	case CompareNoOp:
+		return true
 	default:
 		panic("Unknown operator type")
 	}
@@ -172,6 +179,8 @@ func RunTimeOp(a time.Time, op Operator, b time.Time) bool {
 		return a.After(b)
 	case CompareGTE:
 		return !a.Before(b)
+	case CompareNoOp:
+		return true
 	default:
 		panic("Unknown operator type")
 	}

--- a/graph/iterator/variable.go
+++ b/graph/iterator/variable.go
@@ -45,13 +45,15 @@ type Variable struct {
 	result   graph.Value
 	isBinder bool
 	qs       graph.QuadStore
+	op       Operator
 }
 
-func NewVariable(qs graph.QuadStore, name string) *Variable {
+func NewVariable(qs graph.QuadStore, name string, op Operator) *Variable {
 	it := &Variable{
 		uid:     NextUID(),
 		varName: name,
 		qs:      qs,
+		op:      op,
 	}
 	return it
 }
@@ -82,7 +84,7 @@ func (it *Variable) TagResults(dst map[string]graph.Value) {
 }
 
 func (it *Variable) Clone() graph.Iterator {
-	out := NewVariable(it.qs, it.varName)
+	out := NewVariable(it.qs, it.varName, it.op)
 	out.tags.CopyFrom(it)
 	return out
 }

--- a/graph/memstore/quadstore.go
+++ b/graph/memstore/quadstore.go
@@ -33,9 +33,9 @@ func init() {
 		NewFunc: func(string, graph.Options) (graph.QuadStore, error) {
 			return newQuadStore(), nil
 		},
-		UpgradeFunc:       nil,
-		InitFunc:          nil,
-		IsPersistent:      false,
+		UpgradeFunc:  nil,
+		InitFunc:     nil,
+		IsPersistent: false,
 	})
 }
 
@@ -185,6 +185,10 @@ func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreOpts graph.IgnoreOp
 			return err
 		}
 	}
+	return nil
+}
+
+func (qs *QuadStore) ApplyDeltaStream(in <-chan graph.Delta, opts graph.IgnoreOpts) error {
 	return nil
 }
 

--- a/graph/path/morphism_apply_functions.go
+++ b/graph/path/morphism_apply_functions.go
@@ -490,8 +490,8 @@ func buildHas(qs graph.QuadStore, via interface{}, in graph.Iterator, reverse bo
 
 		if len(nodes) == 1 {
 			switch p := nodes[0].(type) {
-			case graph.Var:
-				return iterator.NewVariable(qs, p.String())
+			case Var:
+				return iterator.NewVariable(qs, p.String(), p.Operator())
 			}
 		}
 

--- a/graph/path/variable.go
+++ b/graph/path/variable.go
@@ -1,13 +1,17 @@
-package graph
+package path
+
+import "github.com/codelingo/cayley/graph/iterator"
 
 type Var struct {
 	name string
+	op   iterator.Operator
 }
 
 // NewVar creates a variable that can be used in place of a graph.Value
-func NewVar(name string) Var {
+func NewVar(name string, op iterator.Operator) Var {
 	return Var{
 		name: name,
+		op:   op,
 	}
 }
 
@@ -17,4 +21,8 @@ func (v Var) String() string {
 
 func (v Var) Native() interface{} {
 	return v.name
+}
+
+func (v Var) Operator() iterator.Operator {
+	return v.op
 }


### PR DESCRIPTION
Add a comparison operator to variables and variable iterators so that they can filter at the Next()/Contains() level. Add a new Comparison type for variables with no comparison.

Update bolt and memstore with ApplyDeltaStream() to conform to new interface.

Take reflect out of Recursive iterator.